### PR TITLE
Render wrong values too after validation fails

### DIFF
--- a/sizefield/widgets.py
+++ b/sizefield/widgets.py
@@ -8,7 +8,10 @@ class FileSizeWidget(forms.TextInput):
 
     def render(self, name, value, attrs=None):
         if value:
-            value = filesizeformat(value)
+            try:
+                value = filesizeformat(value)
+            except ValueError:
+                pass
         return super(FileSizeWidget, self).render(name, value, attrs)
 
     def value_from_datadict(self, data, files, name):


### PR DESCRIPTION
If there is a validation error with the input, the widget can't render it again because it throws ValueError.
