### PR TITLE
Strip whitespace, improve filesize regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ after_success:
 matrix:
     exclude:
         - python: 3.4
-          env: DJANGO_VERSION=1.4.10
+          env: DJANGO_VERSION=1.4.22

--- a/quicktest.py
+++ b/quicktest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import argparse
+import django
 from django.conf import settings
 
 class QuickDjangoTest(object):

--- a/sizefield/tests.py
+++ b/sizefield/tests.py
@@ -66,6 +66,8 @@ class ParseRenderTest(TestCase):
         self.assertEqual(1 << 10, parse_size('1kB'))
         self.assertEqual(1 << 10, parse_size('1kb'))
         self.assertEqual(1 << 10, parse_size('1 kb'))
+        self.assertEqual(1 << 10, parse_size('      1kb'))
+        self.assertEqual(1 << 10, parse_size('1kb      '))
         self.assertEqual(1 << 10, parse_size('1      kb'))
         # Incorrect input
         self.assertRaises(ValueError, parse_size, (''))

--- a/sizefield/tests.py
+++ b/sizefield/tests.py
@@ -61,6 +61,9 @@ class ParseRenderTest(TestCase):
         self.assertEqual((1 << 60) * 0.5, parse_size('0.5EB'))
         self.assertEqual((1 << 70) * 0.5, parse_size('0.5ZB'))
         self.assertEqual((1 << 80) * 0.5, parse_size('0.5YB'))
+        # Unitless values
+        self.assertEqual(1 << 10, parse_size('1K'))
+        self.assertEqual(1 << 30, parse_size('1g'))
         # Case and spaces
         self.assertEqual(1 << 10, parse_size('1Kb'))
         self.assertEqual(1 << 10, parse_size('1kB'))
@@ -75,7 +78,6 @@ class ParseRenderTest(TestCase):
         self.assertRaises(ValueError, parse_size, ('12 HB'))
         self.assertRaises(ValueError, parse_size, ('12 BB'))
         self.assertRaises(ValueError, parse_size, ('12 BKB'))
-        self.assertRaises(ValueError, parse_size, ('12 K'))
         # Already rendered
         self.assertEqual(123, parse_size(123))
 

--- a/sizefield/utils.py
+++ b/sizefield/utils.py
@@ -15,7 +15,7 @@ if sys.version_info >= (3, 0):
 
 SIZEFIELD_FORMAT = getattr(settings, 'SIZEFIELD_FORMAT', '{value}{unit}')
 
-file_size_re = re.compile(r'^(?P<value>[0-9\.,]+?)\s*(?P<unit>([KMGTPEZY]?B)?)$', re.IGNORECASE)
+file_size_re = re.compile(r'^(?P<value>[0-9\.,]+?)\s*(?P<unit>[KMGTPEZY]?B?)$', re.IGNORECASE)
 FILESIZE_UNITS = {
     'B': 1,
     'KB': 1 << 10,
@@ -72,7 +72,9 @@ def parse_size(size):
     if r:
         clean_value = r.group("value").replace(",", ".")
         value = float(clean_value)
-        unit = r.group('unit').upper() or 'B'
+        unit = r.group('unit').upper()
+        if not unit.endswith('B'):
+            unit += 'B'
         return int(value * FILESIZE_UNITS[unit])
 
     # Regex pattern was not matched

--- a/sizefield/utils.py
+++ b/sizefield/utils.py
@@ -15,7 +15,7 @@ if sys.version_info >= (3, 0):
 
 SIZEFIELD_FORMAT = getattr(settings, 'SIZEFIELD_FORMAT', '{value}{unit}')
 
-file_size_re = re.compile(r'^(?P<value>[0-9\.,]+?)\s*(?P<unit>(B{0,1}|[KMGTPEZY]{1}B{1})?)$', re.IGNORECASE)
+file_size_re = re.compile(r'^(?P<value>[0-9\.,]+?)\s*(?P<unit>([KMGTPEZY]?B)?)$', re.IGNORECASE)
 FILESIZE_UNITS = {
     'B': 1,
     'KB': 1 << 10,
@@ -68,7 +68,7 @@ def parse_size(size):
     if isinstance(size, six.integer_types):
         return size
 
-    r = file_size_re.match(size)
+    r = file_size_re.match(size.strip())
     if r:
         clean_value = r.group("value").replace(",", ".")
         value = float(clean_value)


### PR DESCRIPTION
I also wanted to alter the regex to accept the prefix alone (e.g. 4M), but then I've noticed there's a test which assures this doesn't happen. Is there any motivation for this? Should we really enforce proper units (e.g. 4MB)?