### PR TITLE
Django translation fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 *django-sizefield* is a file size field, stored as BigInteger and rendered
-with units in Bytes (KB, MB, ...)
+with units in Bytes (KB, MB, KiB, Mib, ...)
 
 .. image:: https://travis-ci.org/leplatrem/django-sizefield.png
     :target: https://travis-ci.org/leplatrem/django-sizefield
@@ -34,6 +34,13 @@ Model field
 The model form will have a TextInput, which renders the 
 value with units, and accepts values with or without units.
 
+::
+
+    size = FileSizeField(is_binary=False)
+
+It is possible to have fields with decimal size. In this
+instance, a value of 1KB would be parsed as 1000 bytes.
+
 
 Template filter
 ===============
@@ -47,6 +54,30 @@ It adds units to any number value:
     {{ value|filesize }}
 
 *will render 12.3KB (for example)*
+
+To explicitly declare the type of formatting desired, use:
+
+::
+
+    {% custom_filesize 1024 binary=True ambiguous_suffix=False %}
+
+*will render as 1KiB*
+
+
+Settings
+========
+
+By default, 1KB and 1KiB will both parse to 1024 bytes.
+
+::
+
+    SIZEFIELD_IS_BINARY = False
+    SIZEFIELD_AMBIGUOUS_SUFFIX = False
+    SIZEFIELD_ASSUME_BINARY = False
+
+With settings similar to the above, the default will assume
+that 1KB represents 1000 bytes. Formatting from byte values
+will also follow this rule.
 
 
 =======

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,7 @@ AUTHORS
     * Mathieu Leplatre <contact@mathieu-leplatre.info>
     * Alexander (@meteozond)
     * Tom Yam (@perez)
+    * William Tucker <william.tucker@stfc.ac.uk>
 
 
 =======

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 setup(
     name='django-sizefield',
-    version='0.8.dev0',
+    version='0.7.ceda',
     author='Mathieu Leplatre',
     author_email='contact@mathieu-leplatre.info',
     url='https://github.com/leplatrem/django-sizefield',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 setup(
     name='django-sizefield',
-    version='0.7.ceda',
+    version='0.8.dev0',
     author='Mathieu Leplatre',
     author_email='contact@mathieu-leplatre.info',
     url='https://github.com/leplatrem/django-sizefield',

--- a/sizefield/models.py
+++ b/sizefield/models.py
@@ -3,6 +3,7 @@ from django.core import exceptions
 from django.utils.translation import ugettext as _
 
 from sizefield.utils import parse_size
+from sizefield.utils import SIZEFIELD_IS_BINARY
 from sizefield.widgets import FileSizeWidget
 
 
@@ -12,8 +13,18 @@ class FileSizeField(models.BigIntegerField):
         'invalid': _(u'Incorrect file size format.'),
     }
 
+    def __init__(self, is_binary=None, ambiguous_suffix=None, *args, **kwargs):
+        self.is_binary = is_binary
+        self.ambiguous_suffix = ambiguous_suffix
+
+        self.assume_binary = is_binary
+        if is_binary == None:
+            self.assume_binary = SIZEFIELD_IS_BINARY
+
+        super(FileSizeField, self).__init__(*args, **kwargs)
+
     def formfield(self, **kwargs):
-        kwargs['widget'] = FileSizeWidget
+        kwargs['widget'] = FileSizeWidget(is_binary=self.is_binary, ambiguous_suffix=self.ambiguous_suffix, assume_binary=self.assume_binary)
         kwargs['error_messages'] = self.default_error_messages
         return super(FileSizeField, self).formfield(**kwargs)
 
@@ -21,7 +32,7 @@ class FileSizeField(models.BigIntegerField):
         if value is None:
             return None
         try:
-            return parse_size(value)
+            return parse_size(value, assume_binary=self.assume_binary)
         except ValueError:
             raise exceptions.ValidationError(self.error_messages['invalid'])
 

--- a/sizefield/models.py
+++ b/sizefield/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.core import exceptions
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from sizefield.utils import parse_size
 from sizefield.utils import SIZEFIELD_IS_BINARY

--- a/sizefield/models.py
+++ b/sizefield/models.py
@@ -13,13 +13,16 @@ class FileSizeField(models.BigIntegerField):
         'invalid': _(u'Incorrect file size format.'),
     }
 
-    def __init__(self, is_binary=None, ambiguous_suffix=None, *args, **kwargs):
+    def __init__(self, is_binary=None, ambiguous_suffix=None, assume_binary=None, *args, **kwargs):
         self.is_binary = is_binary
         self.ambiguous_suffix = ambiguous_suffix
 
-        self.assume_binary = is_binary
-        if is_binary == None:
-            self.assume_binary = SIZEFIELD_IS_BINARY
+        self.assume_binary = assume_binary
+        if assume_binary == None:
+            # Binary fields are always assumed to be binary when parsed
+            self.assume_binary = is_binary
+            if is_binary == None:
+                self.assume_binary = SIZEFIELD_IS_BINARY
 
         super(FileSizeField, self).__init__(*args, **kwargs)
 

--- a/sizefield/templatetags/sizefieldtags.py
+++ b/sizefield/templatetags/sizefieldtags.py
@@ -7,7 +7,14 @@ register = template.Library()
 
 
 @register.filter(name='filesize')
-def filesize(value, decimals=1, binary=True, ambiguous_suffix=True):
+def filesize(value, decimals=1):
+    if value is None:
+        return ''
+    return filesizeformat(value, decimals)
+
+
+@register.simple_tag(name='custom_filesize')
+def custom_filesize(value, decimals=1, binary=True, ambiguous_suffix=True):
     if value is None:
         return ''
     return filesizeformat(value, decimals, binary, ambiguous_suffix)

--- a/sizefield/templatetags/sizefieldtags.py
+++ b/sizefield/templatetags/sizefieldtags.py
@@ -14,7 +14,11 @@ def filesize(value, decimals=1):
 
 
 @register.simple_tag(name='custom_filesize')
-def custom_filesize(value, decimals=1, is_binary=True, ambiguous_suffix=True):
+def custom_filesize(value, decimals=1, is_binary=None, ambiguous_suffix=None):
+    """
+    Renders the byte value as either binary or decimal using B or iB.
+    """
+
     if value is None:
         return ''
     return filesizeformat(value, decimals=decimals, is_binary=is_binary, ambiguous_suffix=ambiguous_suffix)

--- a/sizefield/templatetags/sizefieldtags.py
+++ b/sizefield/templatetags/sizefieldtags.py
@@ -14,7 +14,7 @@ def filesize(value, decimals=1):
 
 
 @register.simple_tag(name='custom_filesize')
-def custom_filesize(value, decimals=1, binary=True, ambiguous_suffix=True):
+def custom_filesize(value, decimals=1, is_binary=True, ambiguous_suffix=True):
     if value is None:
         return ''
-    return filesizeformat(value, decimals, binary, ambiguous_suffix)
+    return filesizeformat(value, decimals=decimals, is_binary=is_binary, ambiguous_suffix=ambiguous_suffix)

--- a/sizefield/templatetags/sizefieldtags.py
+++ b/sizefield/templatetags/sizefieldtags.py
@@ -7,7 +7,7 @@ register = template.Library()
 
 
 @register.filter(name='filesize')
-def filesize(value, decimals=1):
+def filesize(value, decimals=1, binary=True, ambiguous_suffix=True):
     if value is None:
         return ''
-    return filesizeformat(value, decimals)
+    return filesizeformat(value, decimals, binary, ambiguous_suffix)

--- a/sizefield/tests.py
+++ b/sizefield/tests.py
@@ -43,8 +43,8 @@ class ParseRenderTest(TestCase):
 
         # Unambiguous unit format
         utils.SIZEFIELD_FORMAT = '{value} {unit}'
-        self.assertEqual('1000.0 iB', filesizeformat(1000, ambiguous_suffix=False))
-        self.assertEqual('1023.0 iB', filesizeformat(1023, ambiguous_suffix=False))
+        self.assertEqual('1000.0 B', filesizeformat(1000, ambiguous_suffix=False))
+        self.assertEqual('1023.0 B', filesizeformat(1023, ambiguous_suffix=False))
         self.assertEqual('1.0 KiB', filesizeformat(1024, ambiguous_suffix=False))
         self.assertEqual('1.0 MiB', filesizeformat(1024 * 1024, ambiguous_suffix=False))
         self.assertEqual('1.0 GiB', filesizeformat(1024 * 1024 * 1024, ambiguous_suffix=False))

--- a/sizefield/tests.py
+++ b/sizefield/tests.py
@@ -41,6 +41,33 @@ class ParseRenderTest(TestCase):
         self.assertEqual('1.000xxx KB', filesizeformat(1024, decimals=3))
         self.assertEqual('1.0000xxx KB', filesizeformat(1024, decimals=4))
 
+        # Unambiguous unit format
+        utils.SIZEFIELD_FORMAT = '{value} {unit}'
+        self.assertEqual('1000.0 iB', filesizeformat(1000, ambiguous_suffix=False))
+        self.assertEqual('1023.0 iB', filesizeformat(1023, ambiguous_suffix=False))
+        self.assertEqual('1.0 KiB', filesizeformat(1024, ambiguous_suffix=False))
+        self.assertEqual('1.0 MiB', filesizeformat(1024 * 1024, ambiguous_suffix=False))
+        self.assertEqual('1.0 GiB', filesizeformat(1024 * 1024 * 1024, ambiguous_suffix=False))
+        self.assertEqual('512.0 KiB', filesizeformat(1024 * 1024 * 0.5, ambiguous_suffix=False))
+        self.assertEqual('307.2 KiB', filesizeformat(1024 * 1024 * 0.3, ambiguous_suffix=False))
+
+        # Non binary
+        utils.SIZEFIELD_FORMAT = '{value} {unit}'
+        # Units
+        self.assertEqual('999.0 B', filesizeformat(999, binary=False))
+        self.assertEqual('1.0 KB', filesizeformat(1000, binary=False))
+        self.assertEqual('1.0 MB', filesizeformat(1000 * 1000, binary=False))
+        self.assertEqual('1.0 GB', filesizeformat(1000 * 1000 * 1000, binary=False))
+        self.assertEqual('500.0 KB', filesizeformat(1000 * 1000 * 0.5, binary=False))
+        self.assertEqual('305.5 KB', filesizeformat(1000 * 1000 * 0.3055, binary=False))
+        self.assertEqual('100.0 B', filesizeformat(100, binary=False, ambiguous_suffix=False))
+        # Decimals
+        self.assertEqual('1 KB', filesizeformat(1000, decimals=0, binary=False))
+        self.assertEqual('1.0 KB', filesizeformat(1000, decimals=1, binary=False))
+        self.assertEqual('1.00 KB', filesizeformat(1000, decimals=2, binary=False))
+        self.assertEqual('1.000 KB', filesizeformat(1000, decimals=3, binary=False))
+        self.assertEqual('1.0000 KB', filesizeformat(1000, decimals=4, binary=False))
+
     def test_parse(self):
         # Usual case
         self.assertEqual(123, parse_size('123'))
@@ -61,6 +88,13 @@ class ParseRenderTest(TestCase):
         self.assertEqual((1 << 60) * 0.5, parse_size('0.5EB'))
         self.assertEqual((1 << 70) * 0.5, parse_size('0.5ZB'))
         self.assertEqual((1 << 80) * 0.5, parse_size('0.5YB'))
+        # Unambiguous unit format
+        self.assertEqual(123, parse_size('123iB'))
+        self.assertEqual(123, parse_size('123iB', assume_binary=False))
+        self.assertEqual(1 << 10, parse_size('1KiB'))
+        self.assertEqual(1 << 10, parse_size('1kIb'))
+        self.assertEqual(1 << 10, parse_size('1KIB'))
+        self.assertEqual(1 << 10, parse_size('1KiB', assume_binary=False))
         # Case and spaces
         self.assertEqual(1 << 10, parse_size('1Kb'))
         self.assertEqual(1 << 10, parse_size('1kB'))
@@ -76,6 +110,27 @@ class ParseRenderTest(TestCase):
         self.assertRaises(ValueError, parse_size, ('12 K'))
         # Already rendered
         self.assertEqual(123, parse_size(123))
+        
+        # Non binary
+        # Usual case
+        self.assertEqual(123, parse_size('123', assume_binary=False))
+        self.assertEqual(123, parse_size('123B', assume_binary=False))
+        self.assertEqual(123, parse_size('123 B', assume_binary=False))
+        # Units
+        self.assertEqual(1 * (10 ** 3), parse_size('1KB', assume_binary=False))
+        self.assertEqual(1 * (10 ** 6), parse_size('1MB', assume_binary=False))
+        self.assertEqual(1 * (10 ** 9), parse_size('1GB', assume_binary=False))
+        self.assertEqual(1 * (10 ** 12), parse_size('1TB', assume_binary=False))
+        self.assertEqual(1 * (10 ** 15), parse_size('1PB', assume_binary=False))
+        self.assertEqual(1 * (10 ** 18), parse_size('1EB', assume_binary=False))
+        self.assertEqual((1 * (10 ** 3)) * 0.5, parse_size('0.5KB', assume_binary=False))
+        self.assertEqual((1 * (10 ** 6)) * 0.5, parse_size('0.5MB', assume_binary=False))
+        self.assertEqual((1 * (10 ** 9)) * 0.5, parse_size('0.5GB', assume_binary=False))
+        self.assertEqual((1 * (10 ** 12)) * 0.5, parse_size('0.5TB', assume_binary=False))
+        self.assertEqual((1 * (10 ** 15)) * 0.5, parse_size('0.5PB', assume_binary=False))
+        self.assertEqual((1 * (10 ** 18)) * 0.5, parse_size('0.5EB', assume_binary=False))
+        self.assertEqual((1 * (10 ** 21)) * 0.5, parse_size('0.5ZB', assume_binary=False))
+        self.assertEqual((1 * (10 ** 24)) * 0.5, parse_size('0.5YB', assume_binary=False))
 
 
 class TemplateTagTest(TestCase):

--- a/sizefield/tests.py
+++ b/sizefield/tests.py
@@ -54,19 +54,19 @@ class ParseRenderTest(TestCase):
         # Non binary
         utils.SIZEFIELD_FORMAT = '{value} {unit}'
         # Units
-        self.assertEqual('999.0 B', filesizeformat(999, binary=False))
-        self.assertEqual('1.0 KB', filesizeformat(1000, binary=False))
-        self.assertEqual('1.0 MB', filesizeformat(1000 * 1000, binary=False))
-        self.assertEqual('1.0 GB', filesizeformat(1000 * 1000 * 1000, binary=False))
-        self.assertEqual('500.0 KB', filesizeformat(1000 * 1000 * 0.5, binary=False))
-        self.assertEqual('305.5 KB', filesizeformat(1000 * 1000 * 0.3055, binary=False))
-        self.assertEqual('100.0 B', filesizeformat(100, binary=False, ambiguous_suffix=False))
+        self.assertEqual('999.0 B', filesizeformat(999, is_binary=False))
+        self.assertEqual('1.0 KB', filesizeformat(1000, is_binary=False))
+        self.assertEqual('1.0 MB', filesizeformat(1000 * 1000, is_binary=False))
+        self.assertEqual('1.0 GB', filesizeformat(1000 * 1000 * 1000, is_binary=False))
+        self.assertEqual('500.0 KB', filesizeformat(1000 * 1000 * 0.5, is_binary=False))
+        self.assertEqual('305.5 KB', filesizeformat(1000 * 1000 * 0.3055, is_binary=False))
+        self.assertEqual('100.0 B', filesizeformat(100, is_binary=False, ambiguous_suffix=False))
         # Decimals
-        self.assertEqual('1 KB', filesizeformat(1000, decimals=0, binary=False))
-        self.assertEqual('1.0 KB', filesizeformat(1000, decimals=1, binary=False))
-        self.assertEqual('1.00 KB', filesizeformat(1000, decimals=2, binary=False))
-        self.assertEqual('1.000 KB', filesizeformat(1000, decimals=3, binary=False))
-        self.assertEqual('1.0000 KB', filesizeformat(1000, decimals=4, binary=False))
+        self.assertEqual('1 KB', filesizeformat(1000, decimals=0, is_binary=False))
+        self.assertEqual('1.0 KB', filesizeformat(1000, decimals=1, is_binary=False))
+        self.assertEqual('1.00 KB', filesizeformat(1000, decimals=2, is_binary=False))
+        self.assertEqual('1.000 KB', filesizeformat(1000, decimals=3, is_binary=False))
+        self.assertEqual('1.0000 KB', filesizeformat(1000, decimals=4, is_binary=False))
 
     def test_parse(self):
         # Usual case

--- a/sizefield/utils.py
+++ b/sizefield/utils.py
@@ -11,21 +11,37 @@ from django.conf import settings
 
 SIZEFIELD_FORMAT = getattr(settings, 'SIZEFIELD_FORMAT', '{value}{unit}')
 
-file_size_re = re.compile(r'^(?P<value>[0-9\.,]+?)\s*(?P<unit>(B{0,1}|[KMGTPEZY]{1}B{1})?)$', re.IGNORECASE)
-FILESIZE_UNITS = {
-    'B': 1,
-    'KB': 1 << 10,
-    'MB': 1 << 20,
-    'GB': 1 << 30,
-    'TB': 1 << 40,
-    'PB': 1 << 50,
-    'EB': 1 << 60,
-    'ZB': 1 << 70,
-    'YB': 1 << 80,
+DEFAULT_BYTE_SUFFIX = 'B'
+BINARY_BYTE_SUFFIX = 'iB'
+UNIT_FORMAT = '{unit_size}{byte_suffix}'
+
+#file_size_re = re.compile(r'^(?P<value>[0-9\.,]+?)\s*(?P<unit>(B{0,1}|[KMGTPEZY]{1}i{0,1}B{1})?)$', re.IGNORECASE)
+file_size_re = re.compile(r'^(?P<value>[0-9\.,]+?)\s*(?P<unit_size>[KMGTPEZY]{0,1})(?P<byte_suffix>i{0,1}B{1})?$', re.IGNORECASE)
+FILESIZE_UNITS_BINARY = {
+    '': 1,
+    'K': 1 << 10,
+    'M': 1 << 20,
+    'G': 1 << 30,
+    'T': 1 << 40,
+    'P': 1 << 50,
+    'E': 1 << 60,
+    'Z': 1 << 70,
+    'Y': 1 << 80,
+}
+FILESIZE_UNITS_DECIMAL = {
+    '': 1,
+    'K': 1 * (10 ** 3),
+    'M': 1 * (10 ** 6),
+    'G': 1 * (10 ** 9),
+    'T': 1 * (10 ** 12),
+    'P': 1 * (10 ** 15),
+    'E': 1 * (10 ** 18),
+    'Z': 1 * (10 ** 21),
+    'Y': 1 * (10 ** 24),
 }
 
 
-def filesizeformat(bytes, decimals=1):
+def filesizeformat(bytes, decimals=1, binary=True, ambiguous_suffix=True):
     """
     Formats the value like a 'human-readable' file size (i.e. 13 KB, 4.1 MB,
     102 bytes, etc).
@@ -39,25 +55,34 @@ def filesizeformat(bytes, decimals=1):
 
     filesize_number_format = lambda value: formats.number_format(round(value, decimals), decimals)
 
-    units_list = sorted(six.iteritems(FILESIZE_UNITS), key=operator.itemgetter(1))
+    filesize_units = FILESIZE_UNITS_DECIMAL
+    byte_suffix = DEFAULT_BYTE_SUFFIX
 
-    value = unit = None
+    if binary:
+        filesize_units = FILESIZE_UNITS_BINARY
+        if not ambiguous_suffix:
+            byte_suffix = BINARY_BYTE_SUFFIX
+
+    units_list = sorted(six.iteritems(filesize_units), key=operator.itemgetter(1))
+
+    value = unit_size = None
     len_unints_list = len(units_list)
     for i in xrange(1, len_unints_list):
         if bytes < units_list[i][1]:
             prev_unit = units_list[i - 1]
             value = filesize_number_format(bytes / prev_unit[1])
-            unit = prev_unit[0]
+            unit_size = prev_unit[0]
             break
 
     if value is None:
         value = filesize_number_format(bytes / units_list[-1][1])
-        unit = units_list[-1][0]
+        unit_size = units_list[-1][0]
 
+    unit = UNIT_FORMAT.format(unit_size=unit_size, byte_suffix=byte_suffix)
     return SIZEFIELD_FORMAT.format(value=value, unit=unit)
 
 
-def parse_size(size):
+def parse_size(size, assume_binary=True):
     """
     @rtype int
     """
@@ -66,10 +91,18 @@ def parse_size(size):
 
     r = file_size_re.match(size)
     if r:
-        clean_value = r.group("value").replace(",", ".")
-        value = float(clean_value)
-        unit = r.group('unit').upper() or 'B'
-        return int(value * FILESIZE_UNITS[unit])
+        unit_size = r.group('unit_size').upper() or ''
+        byte_suffix = r.group('byte_suffix') or ''
+
+        if byte_suffix != '' or unit_size == '':
+            clean_value = r.group("value").replace(",", ".")
+            value = float(clean_value)
+
+            file_size_units = FILESIZE_UNITS_BINARY
+            if not assume_binary and byte_suffix.upper() != BINARY_BYTE_SUFFIX.upper():
+                file_size_units = FILESIZE_UNITS_DECIMAL
+
+            return int(value * file_size_units[unit_size])
 
     # Regex pattern was not matched
     raise ValueError(_("Size '%s' has incorrect format") % size)

--- a/sizefield/utils.py
+++ b/sizefield/utils.py
@@ -47,7 +47,8 @@ FILESIZE_UNITS_DECIMAL = {
 def filesizeformat(bytes, decimals=1, is_binary=None, ambiguous_suffix=None):
     """
     Formats the value like a 'human-readable' file size (i.e. 13 KB, 4.1 MB,
-    102 bytes, etc).
+    102 bytes, etc). By default, the value is assumed to be binary with an
+    ambiguous suffix (as opposed to 13 KiB, 4.1 MiB, 102 B, etc).
     Based on django.template.defaultfilters.filesizeformat
     """
 
@@ -86,6 +87,7 @@ def filesizeformat(bytes, decimals=1, is_binary=None, ambiguous_suffix=None):
         value = filesize_number_format(bytes / units_list[-1][1])
         unit_size = units_list[-1][0]
 
+    # If the unit is only iB, use B instead
     if unit_size == '':
         byte_suffix = DEFAULT_BYTE_SUFFIX
 
@@ -112,6 +114,7 @@ def parse_size(size, assume_binary=None):
             clean_value = r.group("value").replace(",", ".")
             value = float(clean_value)
 
+            # Decide whether to parse as a binary or decimal size
             file_size_units = FILESIZE_UNITS_BINARY
             if not assume_binary and byte_suffix.upper() != BINARY_BYTE_SUFFIX.upper():
                 file_size_units = FILESIZE_UNITS_DECIMAL

--- a/sizefield/utils.py
+++ b/sizefield/utils.py
@@ -15,7 +15,6 @@ DEFAULT_BYTE_SUFFIX = 'B'
 BINARY_BYTE_SUFFIX = 'iB'
 UNIT_FORMAT = '{unit_size}{byte_suffix}'
 
-#file_size_re = re.compile(r'^(?P<value>[0-9\.,]+?)\s*(?P<unit>(B{0,1}|[KMGTPEZY]{1}i{0,1}B{1})?)$', re.IGNORECASE)
 file_size_re = re.compile(r'^(?P<value>[0-9\.,]+?)\s*(?P<unit_size>[KMGTPEZY]{0,1})(?P<byte_suffix>i{0,1}B{1})?$', re.IGNORECASE)
 FILESIZE_UNITS_BINARY = {
     '': 1,

--- a/sizefield/utils.py
+++ b/sizefield/utils.py
@@ -77,6 +77,9 @@ def filesizeformat(bytes, decimals=1, binary=True, ambiguous_suffix=True):
         value = filesize_number_format(bytes / units_list[-1][1])
         unit_size = units_list[-1][0]
 
+    if unit_size == '':
+        byte_suffix = DEFAULT_BYTE_SUFFIX
+
     unit = UNIT_FORMAT.format(unit_size=unit_size, byte_suffix=byte_suffix)
     return SIZEFIELD_FORMAT.format(value=value, unit=unit)
 

--- a/sizefield/utils.py
+++ b/sizefield/utils.py
@@ -10,6 +10,8 @@ from django.conf import settings
 
 
 SIZEFIELD_FORMAT = getattr(settings, 'SIZEFIELD_FORMAT', '{value}{unit}')
+SIZEFIELD_IS_BINARY = getattr(settings, 'SIZEFIELD_IS_BINARY', True)
+SIZEFIELD_AMBIGUOUS_SUFFIX = getattr(settings, 'SIZEFIELD_AMBIGUOUS_SUFFIX', True)
 
 DEFAULT_BYTE_SUFFIX = 'B'
 BINARY_BYTE_SUFFIX = 'iB'
@@ -40,7 +42,7 @@ FILESIZE_UNITS_DECIMAL = {
 }
 
 
-def filesizeformat(bytes, decimals=1, binary=True, ambiguous_suffix=True):
+def filesizeformat(bytes, decimals=1, binary=SIZEFIELD_IS_BINARY, ambiguous_suffix=SIZEFIELD_AMBIGUOUS_SUFFIX):
     """
     Formats the value like a 'human-readable' file size (i.e. 13 KB, 4.1 MB,
     102 bytes, etc).
@@ -84,7 +86,7 @@ def filesizeformat(bytes, decimals=1, binary=True, ambiguous_suffix=True):
     return SIZEFIELD_FORMAT.format(value=value, unit=unit)
 
 
-def parse_size(size, assume_binary=True):
+def parse_size(size, assume_binary=SIZEFIELD_AMBIGUOUS_SUFFIX):
     """
     @rtype int
     """

--- a/sizefield/utils.py
+++ b/sizefield/utils.py
@@ -10,8 +10,10 @@ from django.conf import settings
 
 
 SIZEFIELD_FORMAT = getattr(settings, 'SIZEFIELD_FORMAT', '{value}{unit}')
+
 SIZEFIELD_IS_BINARY = getattr(settings, 'SIZEFIELD_IS_BINARY', True)
 SIZEFIELD_AMBIGUOUS_SUFFIX = getattr(settings, 'SIZEFIELD_AMBIGUOUS_SUFFIX', True)
+SIZEFIELD_ASSUME_BINARY = getattr(settings, 'SIZEFIELD_ASSUME_BINARY', SIZEFIELD_IS_BINARY and SIZEFIELD_AMBIGUOUS_SUFFIX)
 
 DEFAULT_BYTE_SUFFIX = 'B'
 BINARY_BYTE_SUFFIX = 'iB'
@@ -42,12 +44,17 @@ FILESIZE_UNITS_DECIMAL = {
 }
 
 
-def filesizeformat(bytes, decimals=1, binary=SIZEFIELD_IS_BINARY, ambiguous_suffix=SIZEFIELD_AMBIGUOUS_SUFFIX):
+def filesizeformat(bytes, decimals=1, is_binary=None, ambiguous_suffix=None):
     """
     Formats the value like a 'human-readable' file size (i.e. 13 KB, 4.1 MB,
     102 bytes, etc).
     Based on django.template.defaultfilters.filesizeformat
     """
+
+    if is_binary == None:
+        is_binary = SIZEFIELD_IS_BINARY
+    if ambiguous_suffix == None:
+        ambiguous_suffix = SIZEFIELD_AMBIGUOUS_SUFFIX
 
     try:
         bytes = float(bytes)
@@ -59,7 +66,7 @@ def filesizeformat(bytes, decimals=1, binary=SIZEFIELD_IS_BINARY, ambiguous_suff
     filesize_units = FILESIZE_UNITS_DECIMAL
     byte_suffix = DEFAULT_BYTE_SUFFIX
 
-    if binary:
+    if is_binary:
         filesize_units = FILESIZE_UNITS_BINARY
         if not ambiguous_suffix:
             byte_suffix = BINARY_BYTE_SUFFIX
@@ -86,12 +93,15 @@ def filesizeformat(bytes, decimals=1, binary=SIZEFIELD_IS_BINARY, ambiguous_suff
     return SIZEFIELD_FORMAT.format(value=value, unit=unit)
 
 
-def parse_size(size, assume_binary=SIZEFIELD_AMBIGUOUS_SUFFIX):
+def parse_size(size, assume_binary=None):
     """
     @rtype int
     """
     if isinstance(size, six.integer_types):
         return size
+
+    if assume_binary == None:
+        assume_binary = SIZEFIELD_ASSUME_BINARY
 
     r = file_size_re.match(size)
     if r:

--- a/sizefield/widgets.py
+++ b/sizefield/widgets.py
@@ -6,10 +6,17 @@ from sizefield.utils import filesizeformat, parse_size
 
 class FileSizeWidget(forms.TextInput):
 
+    def __init__(self, attrs=None, is_binary=None, ambiguous_suffix=None, assume_binary=None):
+        self.attrs = attrs or {}
+
+        self.is_binary = is_binary
+        self.ambiguous_suffix = ambiguous_suffix
+        self.assume_binary = assume_binary
+
     def render(self, name, value, attrs=None):
         if value:
             try:
-                value = filesizeformat(value)
+                value = filesizeformat(value, is_binary=self.is_binary, ambiguous_suffix=self.ambiguous_suffix)
             except ValueError:
                 pass
         return super(FileSizeWidget, self).render(name, value, attrs)
@@ -22,7 +29,7 @@ class FileSizeWidget(forms.TextInput):
         value = super(FileSizeWidget, self).value_from_datadict(data, files, name)
         if value not in EMPTY_VALUES:
             try:
-                return parse_size(value)
+                return parse_size(value, assume_binary=self.assume_binary)
             except ValueError:
                 pass
         return value


### PR DESCRIPTION
This patch solves this error:
"The translation infrastructure cannot be initialized before the "
django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.
