### PR TITLE
Django translation fix

### DIFF
--- a/sizefield/models.py
+++ b/sizefield/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.core import exceptions
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from sizefield.utils import parse_size
 from sizefield.widgets import FileSizeWidget


### PR DESCRIPTION
This patch solves this error:
"The translation infrastructure cannot be initialized before the "
django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.