### PR TITLE
Remove usage of deprecated translation functions

### DIFF
--- a/sizefield/models.py
+++ b/sizefield/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.core import exceptions
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from sizefield.utils import parse_size
 from sizefield.widgets import FileSizeWidget

--- a/sizefield/utils.py
+++ b/sizefield/utils.py
@@ -5,7 +5,7 @@ import re
 import operator
 
 from django.utils import formats
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.conf import settings
 
 


### PR DESCRIPTION
ugettext and ugettext_lazy have been deprecated by gettext and gettext_lazy
since Django 2.0 and Django 4.0 removed them completely.

Closes #22 